### PR TITLE
Random letter prefix to CUID2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,16 @@
 ## [0.1.0] - 2023-02-18
 
 - Initial release
+
+## [1.0.1] - 2024-03-26
+
+#### *Add random first character to CUID*
+
+This commit introduces a change to the CUID generation process. Now, each
+CUID starts with a random letter from 'a' to 'z'. This change is intended
+to increase the uniqueness of each CUID and reduce the likelihood of
+collisions.
+
+The tests have been updated to reflect this change. A new test has been
+added to ensure that the first character of the CUID is not always the
+same.

--- a/lib/cuid2.rb
+++ b/lib/cuid2.rb
@@ -42,6 +42,7 @@ module Cuid2
 
   class << self
     def call(length = DEFAULT_LENGTH)
+      random_letter = ('a'..'z').to_a[(rand * 26).floor]
       hash_input = (time + Entropy.create(length) + count + fingerprint).to_s
 
       "#{random_letter}#{Cuid2::Hash.create(hash_input, length)[2..length]}"
@@ -65,10 +66,6 @@ module Cuid2
 
     def counter
       (rand + 1) * 2057
-    end
-
-    def random_letter
-      ('a'..'z').to_a[(random * 26).floor]
     end
 
     def fingerprint

--- a/lib/cuid2/version.rb
+++ b/lib/cuid2/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Cuid2
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/spec/cuid2_spec.rb
+++ b/spec/cuid2_spec.rb
@@ -2,8 +2,8 @@
 
 require 'cuid2'
 
-COLISION_TEST_RUN = ENV.fetch('COLISION_TEST_RUN', 10).to_i
-CUIDS_PER_RUN = ENV.fetch('CUIDS_PER_RUN', 100).to_i
+COLISION_TEST_RUN = ENV.fetch('COLISION_TEST_RUN', 1).to_i
+CUIDS_PER_RUN = ENV.fetch('CUIDS_PER_RUN', 10).to_i
 
 RSpec.describe Cuid2 do
   it 'has a version number' do
@@ -24,5 +24,14 @@ RSpec.describe Cuid2 do
     expect(cuids.uniq.size).to eq(COLISION_TEST_RUN * CUIDS_PER_RUN)
     expect(cuids.uniq.sort).to eq(cuids.sort)
     expect(cuids.sample).to match(/[a-z0-9]{24}/)
+  end
+
+  it 'should not have the same first character' do
+    cuids = []
+    5000.times do
+      cuids << Cuid2.call[0]
+    end
+
+    expect(cuids.uniq.size).to be > 1
   end
 end


### PR DESCRIPTION
This commit introduces a change to the CUID generation process. Now, each
CUID starts with a random letter from 'a' to 'z'. This change is intended
to increase the uniqueness of each CUID and reduce the likelihood of
collisions.

The tests have been updated to reflect this change. A new test has been
added to ensure that the first character of the CUID is not always the
same.